### PR TITLE
Fixed folder permissions for flatpak

### DIFF
--- a/me.dusansimic.DynamicWallpaper.json
+++ b/me.dusansimic.DynamicWallpaper.json
@@ -10,8 +10,8 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland",
-        "--filesystem=xdg-data/backgrounds",
-        "--filesystem=xdg-data/gnome-background-properties"
+        "--filesystem=xdg-data/backgrounds:create",
+        "--filesystem=xdg-data/gnome-background-properties:create"
     ],
     "cleanup" : [
         "/include",


### PR DESCRIPTION
As noticed in [this issue](https://github.com/dusansimic/dynamic-wallpaper/issues/5), the Flatpak application did not have the necessary permissions to create the `gnome-background-properties` directory in case it didn't exist (as is the case after a fresh install of Fedora, for example). This would result in the application failing silently when trying to create a dynamic background, as it could not create the missing directory and would not report it either.

**To reproduce the issue:**

1. Delete the `$HOME/.local/share/gnome-background-properties` directory.
2. Try and create a dynamic wallpaper using the Flatpak application
3. We will get no reported errors, but when we try to choose this wallpaper in the Gnome background chooser, we will not see it there
4. The chosen images will be in the `$HOME/.local/share/backgrounds` folder, but the `gnome-background-properties` directory will not exist and neither will the .xml file

**This Pull Request fixes this permission problem.**

Added `create` permissions to the two folders used in dynamic background creation, as the Flatpak application could only read and write to them but not create them.