### PR TITLE
Add some fixes to blueprint templates

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -7,7 +7,7 @@ gnome.compile_resources(app_id,
   'me.dusansimic.DynamicWallpaper.gresource.xml',
   gresource_bundle: true,
   install: true,
-  install_dir: join_paths(get_option('prefix'), get_option('datadir'), meson.project_name()),
+  install_dir: join_paths(get_option('datadir'), meson.project_name()),
   dependencies: blueprints
 )
 

--- a/data/ui/gdw-file-row.blp
+++ b/data/ui/gdw-file-row.blp
@@ -5,6 +5,7 @@ template GdwFileRow : Adw.ActionRow {
   Gtk.Button button_open {
     icon-name: "document-open-symbolic";
     valign: center;
+
     styles ["circular"]
   }
 
@@ -12,6 +13,7 @@ template GdwFileRow : Adw.ActionRow {
     visible: false;
     icon-name: "user-trash-symbolic";
     valign: center;
+
     styles ["circular", "destructive-action"]
   }
 

--- a/data/ui/help-overlay.blp
+++ b/data/ui/help-overlay.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Gtk.ShortcutsWindow help_overlay {
   modal: true;
-   
+
   Gtk.ShortcutsSection {
     section-name: "shortcuts";
     max-height: 10;

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -6,73 +6,56 @@ template DynamicWallpaperWindow : Adw.ApplicationWindow {
   default-width: 500;
   default-height: 450;
 
-  Adw.ToastOverlay toast_overlay {
-    Adw.Leaflet leaflet {
-      can-navigate-back: true;
-      can-unfold: false;
+  Gtk.Box {
+    orientation: vertical;
+    Adw.HeaderBar titlebar {
+      centering-policy: strict;
+      title-widget: Adw.WindowTitle {
+        title: _("Dynamic Wallpaper");
+      };
 
-      Gtk.Box main_view {
-        orientation: vertical;
+      [start]
+      Gtk.Button {
+        action-name: "win.create";
 
-        Adw.HeaderBar titlebar {
-          centering-policy: strict;
-
-          [start]
-          Button {
-            action-name: "win.create";
-            
-            Adw.ButtonContent {
-              icon-name: "document-new-symbolic";
-              label: _("Create");
-              tooltip-text: _("Create a new dynamic wallpaper");
-            }
-
-            styles ["suggested-action"]
-          }
-          
-          [title]
-          Label title {
-            label: _("Dynamic Wallpaper");
-          }
-
-          [end]
-          Gtk.MenuButton {
-            tooltip-text: _("Main Menu");
-            icon-name: "open-menu-symbolic";
-            menu-model: main-menu;
-          }
+        Adw.ButtonContent {
+          icon-name: "document-new-symbolic";
+          label: _("Create");
+          tooltip-text: _("Create a new dynamic wallpaper");
         }
 
-        Gtk.Box {
-          orientation: vertical;
+        styles ["suggested-action"]
+      }
 
-          Adw.ViewStack view_stack {
-            vexpand: true;
-            hexpand: true;
+      [end]
+      Gtk.MenuButton {
+        icon-name: "open-menu-symbolic";
+        menu-model: primary_menu;
+      }
+    }
 
-            Adw.ViewStackPage {
-              name: "main";
-              title: _("Dynamic Wallpaper");
-              child: Adw.PreferencesPage content { 
-                Adw.PreferencesGroup input_rows {
-                  Adw.EntryRow entry_name {
-                    title: _("Name");
-                    hexpand: true;
-                  }
+    Adw.ToastOverlay toast_overlay {
+      vexpand: true;
 
-                  styles ["boxed-list"]
-                }
-              };
-            }
+      Adw.Clamp {
+        tightening-threshold: 100;
+        valign: center;
+        margin-top: 36;
+        margin-bottom: 36;
+
+        Adw.PreferencesGroup input_rows {
+          Adw.EntryRow entry_name {
+            title: _("Name");
           }
+
+          styles ["boxed-list"]
         }
       }
     }
   }
 }
 
-
-menu main-menu {
+menu primary_menu {
   section {
     item {
       label: _("Keyboard Shortcuts");
@@ -85,4 +68,3 @@ menu main-menu {
     }
   }
 }
-

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -8,6 +8,7 @@ template DynamicWallpaperWindow : Adw.ApplicationWindow {
 
   Gtk.Box {
     orientation: vertical;
+
     Adw.HeaderBar titlebar {
       centering-policy: strict;
       title-widget: Adw.WindowTitle {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
-moduledir = join_paths(pkgdatadir, 'dynamic_wallpaper')
+moduledir = join_paths(pkgdatadir, 'me.dusansimic.DynamicWallpaper')
 gnome = import('gnome')
 
 python = import('python')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
-moduledir = join_paths(pkgdatadir, 'me.dusansimic.DynamicWallpaper')
+moduledir = join_paths(pkgdatadir, 'dynamic_wallpaper')
 gnome = import('gnome')
 
 python = import('python')


### PR DESCRIPTION
Some things were broken in blueprint templates and were not completely the same as in old xml templates. This patches most of the things so they would look and work as they did before (namely, preferences group being center).