### PR TITLE
appdata: Update appdata

### DIFF
--- a/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
+++ b/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
@@ -6,11 +6,14 @@
   </provides>
   <launchable type="desktop-id">@app_id@.desktop</launchable>
   <name>Dynamic Wallpaper</name>
-  <developer_name>Dušan Simić</developer_name>
+  <developer_name translatable="no">Dušan Simić</developer_name>
   <summary>Create light/dark wallpapers for GNOME 42 and beyond</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <url type="homepage">https://github.com/dusansimic/dynamic-wallpaper</url>
+  <url type="bugtracker">https://github.com/dusansimic/dynamic-wallpaper/issues</url>
+  <url type="vcs-browser">https://github.com/dusansimic/dynamic-wallpaper</url>
+  <url type="translate">https://github.com/dusansimic/dynamic-wallpaper/tree/main/po</url>
   <content_rating type="oars-1.1"/>
   <description>
     <p>
@@ -41,7 +44,7 @@
   </recommends>
   <releases>
     <release version="0.1.0" date="2022-10-13">
-      <description>
+      <description translatable="no">
         <p>New stuff:</p>
         <ul>
           <li>New app design</li>
@@ -50,7 +53,7 @@
       </description>
     </release>
     <release version="0.0.4" date="2022-09-22">
-      <description>
+      <description translatable="no">
         <p>Bug fixes:</p>
         <ul>
           <li>Fix quit keyboard shortcut</li>
@@ -66,7 +69,7 @@
       </description>
     </release>
     <release version="0.0.3" date="2022-06-22">
-      <description>
+      <description translatable="no">
         <p>Window is now draggable from anywhere.</p>
         <p>
           Current icon is fixed to follow Gnome HIG (the one made by Rokwallaby
@@ -84,7 +87,7 @@
       </description>
     </release>
     <release version="0.0.2" date="2022-05-04">
-      <description>
+      <description translatable="no">
         <p>New translations and additional information in about dialog.</p>
         <p>Translated to:</p>
         <ul>
@@ -97,7 +100,7 @@
       </description>
     </release>
     <release version="0.0.1" date="2022-04-25">
-      <description>
+      <description translatable="no">
         <p>First release 🥳</p>
       </description>
     </release>


### PR DESCRIPTION
- Mark release descriptions as untranslatable (1)
- Mark developer name as untranslatable
- Add bugtracker, vcs-browser and translate URLs

1) GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.