### PR TITLE
add more image filetypes

### DIFF
--- a/src/gdwFileRow.py
+++ b/src/gdwFileRow.py
@@ -22,9 +22,13 @@ class FileRow(Adw.ActionRow):
         self._setup_actions(parent)
 
         imgs_filter = Gtk.FileFilter()
-        imgs_filter.set_name(_('PNG & JPEG'))
+        imgs_filter.set_name(_('Images'))
         imgs_filter.add_mime_type('image/png')
         imgs_filter.add_mime_type('image/jpeg')
+        imgs_filter.add_mime_type('image/svg+xml')
+        imgs_filter.add_mime_type('image/webp')
+        imgs_filter.add_mime_type('image/jxl')
+        imgs_filter.add_mime_type('image/avif')
 
         self._chooser = Gtk.FileChooserNative.new(
             _('Select wallpaper'),


### PR DESCRIPTION
closes #65 
closes #76 
closes #79 

Adds file picker support for additional image mimetypes

- SVG (.svg) (image/svg+xml)
- WebP (.webp) (image/webp)
- JPEG XL (.jxl) (image/jxl)
- AVIF (.avif) (image/avif)