### PR TITLE
Add Replace message dialog

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -64,9 +64,26 @@ class DynamicWallpaperWindow(Adw.ApplicationWindow):
         wall_dir = os.path.join(data_dir, 'backgrounds', wp_name)
         xml_path = os.path.join(data_dir, 'gnome-background-properties', '{}.xml'.format(wp_name))
         if any(map(os.path.exists, [wall_dir, xml_path])):
-            self.toast_overlay.add_toast(Adw.Toast.new(_('Wallpaper with the same name already exists')))
-            return
+            dialog = Adw.MessageDialog.new(self, 'Replace File?', 'Wallpaper ' +
+                            'with the same name already exists. ' +
+                            'Do you want to replace it?')
+            dialog.add_response('cancel', 'Cancel')
+            dialog.add_response('replace', 'Replace')
+            dialog.set_response_appearance('replace', Adw.ResponseAppearance.DESTRUCTIVE)
+            dialog.set_default_response('replace')
+            dialog.set_close_response('cancel')
 
+            def on_response(message_dialog, response):
+                match response:
+                    case 'cancel':
+                        return
+                    case 'replace':
+                        self._save_wallpaper(wp_name)
+
+            dialog.connect('response', on_response)
+            dialog.present()
+
+    def _save_wallpaper(self, wp_name):
         try:
             light_path = self.file_light.wp_file.path
             dark_path = self.file_dark.wp_file.path


### PR DESCRIPTION
# Background
closes #78 

# Problem
Users will need to manually delete their existing wallpapers in order to create a new one with the same name

# Proposal
- Add a `Adw.MessageDialog` component which allows the user to _replace_ or _cancel_ the action.

| Action: Replace | Action: Cancel |
|--------|--------|
| ![Replace](https://github.com/dusansimic/dynamic-wallpaper/assets/37822420/f0716632-0fe7-4c8d-b0b5-e44f1abee85d)  | ![Action](https://github.com/dusansimic/dynamic-wallpaper/assets/37822420/69faf634-9490-4b2d-bdeb-95a444db31a1) | 

## Notes
- `Adw.MessageDialog` was implemented as it seems that `Adw.AlertDialog` is not supported.
- The logic related to saving the wallpaper was extracted in a new function so that it could be reused by the _Replace_ action in the dialog.