### PR TITLE
Appdata related patches

### DIFF
--- a/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
+++ b/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
@@ -11,6 +11,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <url type="homepage">https://github.com/dusansimic/dynamic-wallpaper</url>
+  <url type="bugtracker">https://github.com/dusansimic/dynamic-wallpaper/issues</url>
+  <url type="vcs-browser">https://github.com/dusansimic/dynamic-wallpaper</url>
+  <url type="translate">https://github.com/dusansimic/dynamic-wallpaper/tree/main/po</url>
   <content_rating type="oars-1.1"/>
   <description>
     <p>

--- a/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
+++ b/data/me.dusansimic.DynamicWallpaper.appdata.xml.in
@@ -41,7 +41,7 @@
   </recommends>
   <releases>
     <release version="0.1.0" date="2022-10-13">
-      <description>
+      <description translate="no">
         <p>New stuff:</p>
         <ul>
           <li>New app design</li>
@@ -50,7 +50,7 @@
       </description>
     </release>
     <release version="0.0.4" date="2022-09-22">
-      <description>
+      <description translate="no">
         <p>Bug fixes:</p>
         <ul>
           <li>Fix quit keyboard shortcut</li>
@@ -66,7 +66,7 @@
       </description>
     </release>
     <release version="0.0.3" date="2022-06-22">
-      <description>
+      <description translate="no">
         <p>Window is now draggable from anywhere.</p>
         <p>
           Current icon is fixed to follow Gnome HIG (the one made by Rokwallaby
@@ -84,7 +84,7 @@
       </description>
     </release>
     <release version="0.0.2" date="2022-05-04">
-      <description>
+      <description translate="no">
         <p>New translations and additional information in about dialog.</p>
         <p>Translated to:</p>
         <ul>
@@ -97,7 +97,7 @@
       </description>
     </release>
     <release version="0.0.1" date="2022-04-25">
-      <description>
+      <description translate="no">
         <p>First release 🥳</p>
       </description>
     </release>

--- a/data/ui/gdw-file-row.blp
+++ b/data/ui/gdw-file-row.blp
@@ -8,7 +8,7 @@ template GdwFileRow : Adw.ActionRow {
     valign: center;
     child: Adw.ButtonContent button_location_content {
       icon-name: "document-open-symbolic";
-      label: _('(None)');
+      label: _("(None)");
     };
   }
 }


### PR DESCRIPTION
Please review individually. 

### appdata: Mark release descriptions as untranslatable

GNOME automatically excludes release descriptions on Damned Lies
(GNOME Translation Platform). It's a good practice to follow the
GNOME way.

This can streamline the translation process, allowing translators
to focus their efforts on more critical and user-facing aspects of
the application.

### appdata: Add bugtracker, vcs-browser and translate URLs

These URLs are useful to locate source code and translation repositories.